### PR TITLE
Fixed crash on LMB, fixed name of configparser for python 3

### DIFF
--- a/src/tt
+++ b/src/tt
@@ -7,7 +7,7 @@ import requests
 import locale
 import re
 import os
-import ConfigParser
+import configparser
 
 from datetime import datetime
 from json import loads
@@ -196,7 +196,7 @@ def main(scr):
         if c == curses.KEY_MOUSE:
             b, x, y, _, _ = curses.getmouse()
             if b == 0:
-                for c in re.finditer("(\d{3})", scr.instr(y, x-3, 5)):
+                for c in re.finditer(b"(\d{3})", scr.instr(y, x-3, 5)):
                     page_next = c.group(1)
         if c == ord('q'):
             break


### PR DESCRIPTION
Not sure what the function of the LMB relevant line is, but at least it doesn't crash anymore now. The non-capitalized name of configparser should work in python 2 as well.