### PR TITLE
Replaced deprecated SafeConfigParser class with the ConfigParser class

### DIFF
--- a/src/tt
+++ b/src/tt
@@ -261,7 +261,7 @@ def main(scr):
 
     
 if os.path.isfile(TTRC):
-    p = ConfigParser.SafeConfigParser()
+    p = ConfigParser.ConfigParser()
     p.read(TTRC)
     for k, v in p.items('bookmarks'):
         bookmarks[k] = v


### PR DESCRIPTION
When launching the application in Python 3.9, I get the following deprecation warning:

```
/home/dobefu/Downloads/termtekst/src/./tt:264: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  p = ConfigParser.SafeConfigParser()
```